### PR TITLE
Add support for 'collapseActionView' with SearchPreferenceActionView

### DIFF
--- a/app/src/main/res/menu/menu.xml
+++ b/app/src/main/res/menu/menu.xml
@@ -6,6 +6,7 @@
           android:title="title"
           android:icon="@drawable/searchpreference_ic_search"
           android:iconTint="#ffffff"
-          app:showAsAction="always"
+          app:iconTint="#ffffff"
+          app:showAsAction="collapseActionView|ifRoom"
           app:actionViewClass="com.bytehamster.lib.preferencesearch.SearchPreferenceActionView"/>
 </menu>

--- a/lib/src/main/java/com/bytehamster/lib/preferencesearch/SearchPreferenceActionView.java
+++ b/lib/src/main/java/com/bytehamster/lib/preferencesearch/SearchPreferenceActionView.java
@@ -36,7 +36,9 @@ public class SearchPreferenceActionView extends SearchView {
 
             @Override
             public boolean onQueryTextChange(String newText) {
-                searchFragment.setSearchTerm(newText);
+                if (searchFragment != null) {
+                    searchFragment.setSearchTerm(newText);
+                }
                 return true;
             }
         });


### PR DESCRIPTION
Using `app:showAsAction="collapseActionView|ifRoom"` allows to expand the `SearchPreferenceActionView` to span the whole toolbar. However, it causes `onQueryTextChange()` to be called before `searchFragment` is initialized. 
This PR avoids the `NullPointerException` and modifies the `SearchView` example to use `collapseActionView`.

Before and after:
<img src="https://user-images.githubusercontent.com/218061/42425267-2f19cae6-831b-11e8-96f5-74bdda844875.png" alt="searchpreference_searchview_before" width=200> <img src="https://user-images.githubusercontent.com/218061/42425268-2f375e76-831b-11e8-9ba2-a5c7847e94a3.png" alt="searchpreference_searchview_after" width=200>