### PR TITLE
Use 'api' for dependencies exposed via the public API

### DIFF
--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -18,9 +18,9 @@ android {
 }
 
 dependencies {
-    implementation 'com.android.support:appcompat-v7:26.1.0'
+    api 'com.android.support:appcompat-v7:26.1.0'
     implementation 'com.android.support:cardview-v7:26.1.0'
     implementation 'com.android.support:recyclerview-v7:26.1.0'
-    implementation 'com.android.support:preference-v14:26.1.0'
+    api 'com.android.support:preference-v14:26.1.0'
     implementation 'org.apache.commons:commons-text:1.3'
 }


### PR DESCRIPTION
A type from `appcompat-v7` is exposed here: https://github.com/ByteHamster/SearchPreference/blob/de9314c043ac10faae1c531365db571d0bdbbf07/lib/src/main/java/com/bytehamster/lib/preferencesearch/SearchConfiguration.java#L37

A type (indirectly) from `preference-v14` is exposed by subclassing here:
https://github.com/ByteHamster/SearchPreference/blob/de9314c043ac10faae1c531365db571d0bdbbf07/lib/src/main/java/com/bytehamster/lib/preferencesearch/SearchPreference.java#L11


By doing so the dependencies become part of the public API of this library and should be declared as such.