### PR TITLE
Make non fuzzy searches case insensitive by default

### DIFF
--- a/lib/src/main/java/com/bytehamster/lib/preferencesearch/PreferenceItem.java
+++ b/lib/src/main/java/com/bytehamster/lib/preferencesearch/PreferenceItem.java
@@ -31,7 +31,8 @@ class PreferenceItem extends ListItem {
     }
 
     boolean matches(String keyword) {
-        return getInfo().contains(keyword);
+        Locale locale = Locale.getDefault();
+        return getInfo().toLowerCase(locale).contains(keyword.toLowerCase(locale));
     }
 
     float getScore(String keyword) {


### PR DESCRIPTION
Hi there. A problem I had with the library was that the searches were case sensitive with `fuzzySearch` disabled. This way, it was harder to make any search.

Here I add a case sensitivity option. 

I'm happy to do any changes with the approach if necessary.