### PR TITLE
Make possible to index and ignore preferences programatically

### DIFF
--- a/lib/src/main/java/com/bytehamster/lib/preferencesearch/PreferenceItem.java
+++ b/lib/src/main/java/com/bytehamster/lib/preferencesearch/PreferenceItem.java
@@ -1,12 +1,14 @@
 package com.bytehamster.lib.preferencesearch;
 
+import android.os.Parcel;
+import android.os.Parcelable;
 import android.text.TextUtils;
 import org.apache.commons.text.similarity.FuzzyScore;
 
 import java.util.ArrayList;
 import java.util.Locale;
 
-class PreferenceItem extends ListItem {
+class PreferenceItem extends ListItem implements Parcelable {
     static final int TYPE = 2;
     private static FuzzyScore fuzzyScore = new FuzzyScore(Locale.getDefault());
 
@@ -21,6 +23,30 @@ class PreferenceItem extends ListItem {
 
     private float lastScore = 0;
     private String lastKeyword = null;
+
+    PreferenceItem() {
+    }
+
+    private PreferenceItem(Parcel in) {
+        this.title = in.readString();
+        this.summary = in.readString();
+        this.key = in.readString();
+        this.breadcrumbs = in.readString();
+        this.keywords = in.readString();
+        this.resId = in.readInt();
+    }
+
+    public static final Creator<PreferenceItem> CREATOR = new Creator<PreferenceItem>() {
+        @Override
+        public PreferenceItem createFromParcel(Parcel in) {
+            return new PreferenceItem(in);
+        }
+
+        @Override
+        public PreferenceItem[] newArray(int size) {
+            return new PreferenceItem[size];
+        }
+    };
 
     boolean hasData() {
         return title != null || summary != null;
@@ -81,4 +107,20 @@ class PreferenceItem extends ListItem {
     public int getType() {
         return TYPE;
     }
+
+    @Override
+    public int describeContents() {
+        return 0;
+    }
+
+    @Override
+    public void writeToParcel(Parcel parcel, int i) {
+        parcel.writeString(title);
+        parcel.writeString(summary);
+        parcel.writeString(key);
+        parcel.writeString(breadcrumbs);
+        parcel.writeString(keywords);
+        parcel.writeInt(resId);
+    }
+
 }

--- a/lib/src/main/java/com/bytehamster/lib/preferencesearch/PreferenceItem.java
+++ b/lib/src/main/java/com/bytehamster/lib/preferencesearch/PreferenceItem.java
@@ -3,12 +3,13 @@ package com.bytehamster.lib.preferencesearch;
 import android.os.Parcel;
 import android.os.Parcelable;
 import android.text.TextUtils;
+import androidx.annotation.XmlRes;
 import org.apache.commons.text.similarity.FuzzyScore;
 
 import java.util.ArrayList;
 import java.util.Locale;
 
-class PreferenceItem extends ListItem implements Parcelable {
+public class PreferenceItem extends ListItem implements Parcelable {
     static final int TYPE = 2;
     private static FuzzyScore fuzzyScore = new FuzzyScore(Locale.getDefault());
 
@@ -97,6 +98,44 @@ class PreferenceItem extends ListItem implements Parcelable {
         return infoBuilder.toString();
     }
 
+    public PreferenceItem withKey(String key) {
+        this.key = key;
+        return this;
+    }
+
+    public PreferenceItem withSummary(String summary) {
+        this.summary = summary;
+        return this;
+    }
+
+    public PreferenceItem withTitle(String title) {
+        this.title = title;
+        return this;
+    }
+
+    public PreferenceItem withEntries(String entries) {
+        this.entries = entries;
+        return this;
+    }
+
+    public PreferenceItem withKeywords(String keywords) {
+        this.keywords = keywords;
+        return this;
+    }
+
+    public PreferenceItem withResId(@XmlRes Integer resId) {
+        this.resId = resId;
+        return this;
+    }
+
+    /**
+     * @param breadcrumb The breadcrumb to add
+     * @return For chaining
+     */
+    public PreferenceItem addBreadcrumb(String breadcrumb) {
+        this.breadcrumbs = Breadcrumb.concat(this.breadcrumbs, breadcrumb);
+        return this;
+    }
 
     @Override
     public String toString() {

--- a/lib/src/main/java/com/bytehamster/lib/preferencesearch/PreferenceParser.java
+++ b/lib/src/main/java/com/bytehamster/lib/preferencesearch/PreferenceParser.java
@@ -30,6 +30,10 @@ class PreferenceParser {
         allEntries.addAll(parseFile(item));
     }
 
+    void addPreferenceItems(ArrayList<PreferenceItem> preferenceItems) {
+        allEntries.addAll(preferenceItems);
+    }
+
     private ArrayList<PreferenceItem> parseFile(SearchConfiguration.SearchIndexItem item) {
         java.util.ArrayList<PreferenceItem> results = new ArrayList<>();
         XmlPullParser xpp = context.getResources().getXml(item.getResId());

--- a/lib/src/main/java/com/bytehamster/lib/preferencesearch/PreferenceParser.java
+++ b/lib/src/main/java/com/bytehamster/lib/preferencesearch/PreferenceParser.java
@@ -37,6 +37,7 @@ class PreferenceParser {
     private ArrayList<PreferenceItem> parseFile(SearchConfiguration.SearchIndexItem item) {
         java.util.ArrayList<PreferenceItem> results = new ArrayList<>();
         XmlPullParser xpp = context.getResources().getXml(item.getResId());
+        List<String> bannedKeys = item.getSearchConfiguration().getBannedKeys();
 
         try {
             xpp.setFeature(XmlPullParser.FEATURE_PROCESS_NAMESPACES, true);
@@ -54,7 +55,7 @@ class PreferenceParser {
                     if (!BLACKLIST.contains(xpp.getName())
                             && result.hasData()
                             && !"true".equals(getAttribute(xpp, NS_SEARCH, "ignore"))
-                    ) {
+                            && !bannedKeys.contains(result.key)) {
                         result.breadcrumbs = joinBreadcrumbs(breadcrumbs);
                         result.keyBreadcrumbs = cleanupKeyBreadcrumbs(keyBreadcrumbs);
                         results.add(result);

--- a/lib/src/main/java/com/bytehamster/lib/preferencesearch/PreferenceParser.java
+++ b/lib/src/main/java/com/bytehamster/lib/preferencesearch/PreferenceParser.java
@@ -51,12 +51,13 @@ class PreferenceParser {
                     PreferenceItem result = parseSearchResult(xpp);
                     result.resId = item.getResId();
 
-                    if (!BLACKLIST.contains(xpp.getName()) && result.hasData()) {
+                    if (!BLACKLIST.contains(xpp.getName())
+                            && result.hasData()
+                            && !"true".equals(getAttribute(xpp, NS_SEARCH, "ignore"))
+                    ) {
                         result.breadcrumbs = joinBreadcrumbs(breadcrumbs);
                         result.keyBreadcrumbs = cleanupKeyBreadcrumbs(keyBreadcrumbs);
-                        if (!"true".equals(getAttribute(xpp, NS_SEARCH, "ignore"))) {
-                            results.add(result);
-                        }
+                        results.add(result);
                     }
                     if (CONTAINERS.contains(xpp.getName())) {
                         breadcrumbs.add(result.title == null ? "" : result.title);

--- a/lib/src/main/java/com/bytehamster/lib/preferencesearch/SearchConfiguration.java
+++ b/lib/src/main/java/com/bytehamster/lib/preferencesearch/SearchConfiguration.java
@@ -14,7 +14,7 @@ import com.bytehamster.lib.preferencesearch.ui.RevealAnimationSetting;
 import java.util.ArrayList;
 
 public class SearchConfiguration {
-    private static final String ARGUMENT_INDEX_ITEMS = "items";
+    private static final String ARGUMENT_INDEX_FILES = "items";
     private static final String ARGUMENT_FUZZY_ENABLED = "fuzzy";
     private static final String ARGUMENT_HISTORY_ENABLED = "history_enabled";
     private static final String ARGUMENT_SEARCH_BAR_ENABLED = "search_bar_enabled";
@@ -24,7 +24,7 @@ public class SearchConfiguration {
     private static final String ARGUMENT_TEXT_CLEAR_HISTORY = "text_clear_history";
     private static final String ARGUMENT_TEXT_NO_RESULTS = "text_no_results";
 
-    private ArrayList<SearchIndexItem> itemsToIndex = new ArrayList<>();
+    private ArrayList<SearchIndexItem> filesToIndex = new ArrayList<>();
     private boolean historyEnabled = true;
     private boolean breadcrumbsEnabled = false;
     private boolean fuzzySearchEnabled = true;
@@ -69,7 +69,7 @@ public class SearchConfiguration {
 
     private Bundle toBundle() {
         Bundle arguments = new Bundle();
-        arguments.putParcelableArrayList(ARGUMENT_INDEX_ITEMS, itemsToIndex);
+        arguments.putParcelableArrayList(ARGUMENT_INDEX_FILES, filesToIndex);
         arguments.putBoolean(ARGUMENT_HISTORY_ENABLED, historyEnabled);
         arguments.putParcelable(ARGUMENT_REVEAL_ANIMATION_SETTING, revealAnimationSetting);
         arguments.putBoolean(ARGUMENT_FUZZY_ENABLED, fuzzySearchEnabled);
@@ -83,7 +83,7 @@ public class SearchConfiguration {
 
     static SearchConfiguration fromBundle(Bundle bundle) {
         SearchConfiguration config = new SearchConfiguration();
-        config.itemsToIndex = bundle.getParcelableArrayList(ARGUMENT_INDEX_ITEMS);
+        config.filesToIndex = bundle.getParcelableArrayList(ARGUMENT_INDEX_FILES);
         config.historyEnabled = bundle.getBoolean(ARGUMENT_HISTORY_ENABLED);
         config.revealAnimationSetting = bundle.getParcelable(ARGUMENT_REVEAL_ANIMATION_SETTING);
         config.fuzzySearchEnabled = bundle.getBoolean(ARGUMENT_FUZZY_ENABLED);
@@ -167,12 +167,12 @@ public class SearchConfiguration {
      */
     public SearchIndexItem index(@XmlRes int resId) {
         SearchIndexItem item = new SearchIndexItem(resId, this);
-        itemsToIndex.add(item);
+        filesToIndex.add(item);
         return item;
     }
 
     ArrayList<SearchIndexItem> getFiles() {
-        return itemsToIndex;
+        return filesToIndex;
     }
 
     boolean isHistoryEnabled() {

--- a/lib/src/main/java/com/bytehamster/lib/preferencesearch/SearchConfiguration.java
+++ b/lib/src/main/java/com/bytehamster/lib/preferencesearch/SearchConfiguration.java
@@ -9,12 +9,16 @@ import androidx.annotation.NonNull;
 import androidx.annotation.StringRes;
 import androidx.annotation.XmlRes;
 import androidx.appcompat.app.AppCompatActivity;
+import androidx.preference.ListPreference;
+import androidx.preference.Preference;
 import com.bytehamster.lib.preferencesearch.ui.RevealAnimationSetting;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 
 public class SearchConfiguration {
     private static final String ARGUMENT_INDEX_FILES = "items";
+    private static final String ARGUMENT_INDEX_INDIVIDUAL_PREFERENCES = "individual_prefs";
     private static final String ARGUMENT_FUZZY_ENABLED = "fuzzy";
     private static final String ARGUMENT_HISTORY_ENABLED = "history_enabled";
     private static final String ARGUMENT_SEARCH_BAR_ENABLED = "search_bar_enabled";
@@ -25,6 +29,7 @@ public class SearchConfiguration {
     private static final String ARGUMENT_TEXT_NO_RESULTS = "text_no_results";
 
     private ArrayList<SearchIndexItem> filesToIndex = new ArrayList<>();
+    private ArrayList<PreferenceItem> preferencesToIndex = new ArrayList<>();
     private boolean historyEnabled = true;
     private boolean breadcrumbsEnabled = false;
     private boolean fuzzySearchEnabled = true;
@@ -70,6 +75,7 @@ public class SearchConfiguration {
     private Bundle toBundle() {
         Bundle arguments = new Bundle();
         arguments.putParcelableArrayList(ARGUMENT_INDEX_FILES, filesToIndex);
+        arguments.putParcelableArrayList(ARGUMENT_INDEX_INDIVIDUAL_PREFERENCES, preferencesToIndex);
         arguments.putBoolean(ARGUMENT_HISTORY_ENABLED, historyEnabled);
         arguments.putParcelable(ARGUMENT_REVEAL_ANIMATION_SETTING, revealAnimationSetting);
         arguments.putBoolean(ARGUMENT_FUZZY_ENABLED, fuzzySearchEnabled);
@@ -84,6 +90,7 @@ public class SearchConfiguration {
     static SearchConfiguration fromBundle(Bundle bundle) {
         SearchConfiguration config = new SearchConfiguration();
         config.filesToIndex = bundle.getParcelableArrayList(ARGUMENT_INDEX_FILES);
+        config.preferencesToIndex = bundle.getParcelableArrayList(ARGUMENT_INDEX_INDIVIDUAL_PREFERENCES);
         config.historyEnabled = bundle.getBoolean(ARGUMENT_HISTORY_ENABLED);
         config.revealAnimationSetting = bundle.getParcelable(ARGUMENT_REVEAL_ANIMATION_SETTING);
         config.fuzzySearchEnabled = bundle.getBoolean(ARGUMENT_FUZZY_ENABLED);
@@ -171,8 +178,51 @@ public class SearchConfiguration {
         return item;
     }
 
+    /**
+     * Indexes a single preference
+     * @return the indexed PreferenceItem to configure it with chaining
+     * @see PreferenceItem for the available methods for configuring it
+     */
+    public PreferenceItem indexItem() {
+        PreferenceItem preferenceItem = new PreferenceItem();
+        preferencesToIndex.add(preferenceItem);
+        return preferenceItem;
+    }
+
+    /**
+     * Indexes a single android preference
+     * @param preference to get its key, summary, title and entries
+     * @return the indexed PreferenceItem to configure it with chaining
+     * @see PreferenceItem for the available methods for configuring it
+     */
+    public PreferenceItem indexItem(@NonNull Preference preference) {
+        PreferenceItem preferenceItem = new PreferenceItem();
+
+        if (preference.getKey() != null) {
+            preferenceItem.key = preference.getKey();
+        }
+        if (preference.getSummary() != null) {
+            preferenceItem.summary = preference.getSummary().toString();
+        }
+        if (preference.getTitle() != null) {
+            preferenceItem.title = preference.getTitle().toString();
+        }
+        if (preference instanceof ListPreference) {
+            ListPreference listPreference = ((ListPreference) preference);
+            if (listPreference.getEntries() != null) {
+                preferenceItem.entries = Arrays.toString(listPreference.getEntries());
+            }
+        }
+        preferencesToIndex.add(preferenceItem);
+        return preferenceItem;
+    }
+
     ArrayList<SearchIndexItem> getFiles() {
         return filesToIndex;
+    }
+
+    ArrayList<PreferenceItem> getPreferencesToIndex() {
+        return preferencesToIndex;
     }
 
     boolean isHistoryEnabled() {

--- a/lib/src/main/java/com/bytehamster/lib/preferencesearch/SearchConfiguration.java
+++ b/lib/src/main/java/com/bytehamster/lib/preferencesearch/SearchConfiguration.java
@@ -30,6 +30,7 @@ public class SearchConfiguration {
 
     private ArrayList<SearchIndexItem> filesToIndex = new ArrayList<>();
     private ArrayList<PreferenceItem> preferencesToIndex = new ArrayList<>();
+    private ArrayList<String> bannedKeys = new ArrayList<>();
     private boolean historyEnabled = true;
     private boolean breadcrumbsEnabled = false;
     private boolean fuzzySearchEnabled = true;
@@ -217,6 +218,17 @@ public class SearchConfiguration {
         return preferenceItem;
     }
 
+    ArrayList<String> getBannedKeys() {
+        return bannedKeys;
+    }
+
+    /**
+     * @param key of the preference to be ignored
+     */
+    public void ignorePreference(@NonNull String key) {
+        bannedKeys.add(key);
+    }
+
     ArrayList<SearchIndexItem> getFiles() {
         return filesToIndex;
     }
@@ -322,6 +334,10 @@ public class SearchConfiguration {
 
         String getBreadcrumb() {
             return breadcrumb;
+        }
+
+        SearchConfiguration getSearchConfiguration() {
+            return searchConfiguration;
         }
 
         public static final Creator<SearchIndexItem> CREATOR = new Creator<SearchIndexItem>() {

--- a/lib/src/main/java/com/bytehamster/lib/preferencesearch/SearchPreferenceFragment.java
+++ b/lib/src/main/java/com/bytehamster/lib/preferencesearch/SearchPreferenceFragment.java
@@ -52,6 +52,7 @@ public class SearchPreferenceFragment extends Fragment implements SearchPreferen
         for (SearchConfiguration.SearchIndexItem file : files) {
             searcher.addResourceFile(file);
         }
+        searcher.addPreferenceItems(searchConfiguration.getPreferencesToIndex());
         loadHistory();
     }
 


### PR DESCRIPTION
Hi there! Here's the PR I said I would do.

This aims to solve two problems of mine:
- Index preferences programatically: as some are built programatically on AnkiDroid instead of on the XMLs
- Ignore preferences programatically: as some can't be used by everyone, e.g. newer API features and device specific settings (e.g. E-ink)

Please feel free to push back about the implementation.

I think I won't need any more changes to the library, so you can release a new version after this is merged. Pinging @ByteHamster just in case you haven't got the notification. Sorry to bother.