### PR TITLE
Make history id configurable

### DIFF
--- a/lib/src/main/java/com/bytehamster/lib/preferencesearch/SearchConfiguration.java
+++ b/lib/src/main/java/com/bytehamster/lib/preferencesearch/SearchConfiguration.java
@@ -21,6 +21,7 @@ public class SearchConfiguration {
     private static final String ARGUMENT_INDEX_INDIVIDUAL_PREFERENCES = "individual_prefs";
     private static final String ARGUMENT_FUZZY_ENABLED = "fuzzy";
     private static final String ARGUMENT_HISTORY_ENABLED = "history_enabled";
+    private static final String ARGUMENT_HISTORY_ID = "history_id";
     private static final String ARGUMENT_SEARCH_BAR_ENABLED = "search_bar_enabled";
     private static final String ARGUMENT_BREADCRUMBS_ENABLED = "breadcrumbs_enabled";
     private static final String ARGUMENT_REVEAL_ANIMATION_SETTING = "reveal_anim_setting";
@@ -32,6 +33,7 @@ public class SearchConfiguration {
     private ArrayList<PreferenceItem> preferencesToIndex = new ArrayList<>();
     private ArrayList<String> bannedKeys = new ArrayList<>();
     private boolean historyEnabled = true;
+    private String historyId = null;
     private boolean breadcrumbsEnabled = false;
     private boolean fuzzySearchEnabled = true;
     private boolean searchBarEnabled = true;
@@ -85,6 +87,7 @@ public class SearchConfiguration {
         arguments.putString(ARGUMENT_TEXT_HINT, textHint);
         arguments.putString(ARGUMENT_TEXT_CLEAR_HISTORY, textClearHistory);
         arguments.putString(ARGUMENT_TEXT_NO_RESULTS, textNoResults);
+        arguments.putString(ARGUMENT_HISTORY_ID, historyId);
         return arguments;
     }
 
@@ -100,6 +103,7 @@ public class SearchConfiguration {
         config.textHint = bundle.getString(ARGUMENT_TEXT_HINT);
         config.textClearHistory = bundle.getString(ARGUMENT_TEXT_CLEAR_HISTORY);
         config.textNoResults = bundle.getString(ARGUMENT_TEXT_NO_RESULTS);
+        config.historyId = bundle.getString(ARGUMENT_HISTORY_ID);
         return config;
     }
 
@@ -120,6 +124,15 @@ public class SearchConfiguration {
      */
     public void setHistoryEnabled(boolean historyEnabled) {
         this.historyEnabled = historyEnabled;
+    }
+
+    /**
+     * Sets the id to use for saving the history. Preference screens with the same history id will share the same
+     * history. The default id is null (no id).
+     * @param historyId the history id
+     */
+    public void setHistoryId(String historyId) {
+        this.historyId = historyId;
     }
 
     /**
@@ -239,6 +252,10 @@ public class SearchConfiguration {
 
     boolean isHistoryEnabled() {
         return historyEnabled;
+    }
+
+    String getHistoryId() {
+        return historyId;
     }
 
     boolean isBreadcrumbsEnabled() {

--- a/lib/src/main/java/com/bytehamster/lib/preferencesearch/SearchPreferenceFragment.java
+++ b/lib/src/main/java/com/bytehamster/lib/preferencesearch/SearchPreferenceFragment.java
@@ -114,20 +114,44 @@ public class SearchPreferenceFragment extends Fragment implements SearchPreferen
             return;
         }
 
-        int size = prefs.getInt("history_size", 0);
+        int size = prefs.getInt(historySizeKey(), 0);
         for (int i = 0; i < size; i++) {
-            String title = prefs.getString("history_" + i, null);
+            String title = prefs.getString(historyEntryKey(i), null);
             history.add(new HistoryItem(title));
         }
     }
 
     private void saveHistory() {
         SharedPreferences.Editor editor = prefs.edit();
-        editor.putInt("history_size", history.size());
+        editor.putInt(historySizeKey(), history.size());
         for (int i = 0; i < history.size(); i++) {
-            editor.putString("history_" + i, history.get(i).getTerm());
+            editor.putString(historyEntryKey(i), history.get(i).getTerm());
         }
         editor.apply();
+    }
+
+    /**
+     * Gets the preference key for the history size, prefixed with the history ID, if set.
+     * @return the preference key for the history size
+     */
+    private String historySizeKey() {
+        if (searchConfiguration.getHistoryId() != null) {
+            return searchConfiguration.getHistoryId() + "_history_size";
+        } else {
+            return "history_size";
+        }
+    }
+
+    /**
+     * Gets the preference key for a history entry, prefixed with the history ID, if set.
+     * @return the preference key for the history entry
+     */
+    private String historyEntryKey(int i) {
+        if (searchConfiguration.getHistoryId() != null) {
+            return searchConfiguration.getHistoryId() + "_history_" + i;
+        } else {
+            return "history_" + i;
+        }
     }
 
     private void clearHistory() {


### PR DESCRIPTION
This PR allows for the history ID to be configurable, so that unrelated preference screens can use different IDs and not share a history.

Default value for the ID is null, not adding a prefix and keeping the previous behavior / not losing existing history.

Closes #28