### PR TITLE
Add edge-to-edge handling to SearchPreferenceFragment

### DIFF
--- a/lib/src/main/res/layout/searchpreference_fragment.xml
+++ b/lib/src/main/res/layout/searchpreference_fragment.xml
@@ -5,7 +5,8 @@
         android:layout_width="match_parent"
         android:orientation="vertical"
         android:clipToPadding="false"
-        android:background="?android:attr/windowBackground">
+        android:background="?android:attr/windowBackground"
+        android:fitsSystemWindows="true">
 
     <include layout="@layout/searchpreference_searchbar"
              android:layout_marginLeft="8dp"


### PR DESCRIPTION
Fixes: #43 

As mentioned in the issue report, apps targeting Android SDK 35+ will see issues with SearchPreferenceFragment. By adding this XML attribute (android:fitsSystemWindows="true") to the root layout of the Fragment, this resolves the issue.